### PR TITLE
Use DateTime-Object to convert the time to a timestamp

### DIFF
--- a/src/Filter/DateTimeToTimestamp.php
+++ b/src/Filter/DateTimeToTimestamp.php
@@ -32,15 +32,14 @@ class DateTimeToTimestamp extends AbstractFilter
      */
     public function filter($value)
     {
-        $ret = null;
-
-        $timestamp = strtotime("{$value}+00:00");
-
-        if (is_integer($timestamp)) {
-            $ret = $timestamp;
+        try {
+            $time = new DateTime($value, new DateTimeZone('UTC'));
+            $time->setTimzone(new DateTimeZone('UTC'));
+        } catch (Exception $e) {
+            return null;
         }
 
-        return $ret;
+        return $time->format('U');
     }
 
 }


### PR DESCRIPTION
This uses a DateTime-Object to convert the datetime to a UTC-timestamp.

The extra `setTimezone` causes the DateTime-Object to be converted to UTC even when the datetimestring $value should contain a UTC-Offset just to be on the safe side ;)
