### PR TITLE
Adapts tests to reflect different default-timezone

### DIFF
--- a/test/Filter/DateTimeToTimestampTest.php
+++ b/test/Filter/DateTimeToTimestampTest.php
@@ -9,64 +9,84 @@ use TxTextControl\ReportingCloud\Filter\DateTimeToTimestamp as Filter;
 class DateTimeToTimestampTest extends PHPUnit_Framework_TestCase
 {
     protected $filter;
+    
+    protected $defaultTimezone;
 
     public function setUp()
     {
         $this->filter = new Filter();
+        $this->defaultTimezone = date_default_timezone_get();
+    }
+    
+    public function tearDown()
+    {
+        date_default_timezone_set($this->defaultTimezone);
+        parent::tearDown();
     }
 
-    public function testDefault()
+    /** @dataProvider defaultProvider */
+    public function testDefault($timezone, $datetime, $timestamp)
     {
-        $this->assertEquals(685431539,  $this->filter->filter('1991-09-21T05:38:59'));
-        $this->assertEquals(1456954200, $this->filter->filter('2016-03-02T21:30:00'));
-        $this->assertEquals(635899288,  $this->filter->filter('1990-02-24T22:41:28'));
-        $this->assertEquals(649366715,  $this->filter->filter('1990-07-30T19:38:35'));
-        $this->assertEquals(5748313,    $this->filter->filter('1970-03-08T12:45:13'));
-        $this->assertEquals(817934028,  $this->filter->filter('1995-12-02T19:53:48'));
-        $this->assertEquals(45876855,   $this->filter->filter('1971-06-15T23:34:15'));
-        $this->assertEquals(160579014,  $this->filter->filter('1975-02-02T13:16:54'));
-        $this->assertEquals(629337306,  $this->filter->filter('1989-12-10T23:55:06'));
-        $this->assertEquals(249683354,  $this->filter->filter('1977-11-29T20:29:14'));
-        $this->assertEquals(118212340,  $this->filter->filter('1973-09-30T04:45:40'));
-        $this->assertEquals(1441792051, $this->filter->filter('2015-09-09T09:47:31'));
-        $this->assertEquals(487553515,  $this->filter->filter('1985-06-13T23:31:55'));
-        $this->assertEquals(901837811,  $this->filter->filter('1998-07-30T22:30:11'));
-        $this->assertEquals(301700008,  $this->filter->filter('1979-07-24T21:33:28'));
-        $this->assertEquals(459508113,  $this->filter->filter('1984-07-24T09:08:33'));
-        $this->assertEquals(459914029,  $this->filter->filter('1984-07-29T01:53:49'));
-        $this->assertEquals(1331022551, $this->filter->filter('2012-03-06T08:29:11'));
-        $this->assertEquals(628073482,  $this->filter->filter('1989-11-26T08:51:22'));
-        $this->assertEquals(1080281100, $this->filter->filter('2004-03-26T06:05:00'));
-        $this->assertEquals(800521958,  $this->filter->filter('1995-05-15T07:12:38'));
-        $this->assertEquals(714206234,  $this->filter->filter('1992-08-19T06:37:14'));
-        $this->assertEquals(981854794,  $this->filter->filter('2001-02-11T01:26:34'));
-        $this->assertEquals(1286683509, $this->filter->filter('2010-10-10T04:05:09'));
-        $this->assertEquals(203664077,  $this->filter->filter('1976-06-15T05:21:17'));
-        $this->assertEquals(392912719,  $this->filter->filter('1982-06-14T14:25:19'));
-        $this->assertEquals(1311458999, $this->filter->filter('2011-07-23T22:09:59'));
-        $this->assertEquals(442916997,  $this->filter->filter('1984-01-14T08:29:57'));
-        $this->assertEquals(1121576074, $this->filter->filter('2005-07-17T04:54:34'));
-        $this->assertEquals(762097629,  $this->filter->filter('1994-02-24T13:47:09'));
-        $this->assertEquals(132413682,  $this->filter->filter('1974-03-13T13:34:42'));
-        $this->assertEquals(341989899,  $this->filter->filter('1980-11-02T05:11:39'));
-        $this->assertEquals(754034117,  $this->filter->filter('1993-11-23T05:55:17'));
-        $this->assertEquals(768312970,  $this->filter->filter('1994-05-07T12:16:10'));
-        $this->assertEquals(991356614,  $this->filter->filter('2001-06-01T00:50:14'));
-        $this->assertEquals(759782429,  $this->filter->filter('1994-01-28T18:40:29'));
-        $this->assertEquals(121229284,  $this->filter->filter('1973-11-04T02:48:04'));
-        $this->assertEquals(1037233469, $this->filter->filter('2002-11-14T00:24:29'));
-        $this->assertEquals(920361442,  $this->filter->filter('1999-03-02T07:57:22'));
-        $this->assertEquals(750566590,  $this->filter->filter('1993-10-14T02:43:10'));
-        $this->assertEquals(1286916823, $this->filter->filter('2010-10-12T20:53:43'));
-        $this->assertEquals(1038573783, $this->filter->filter('2002-11-29T12:43:03'));
-        $this->assertEquals(727340928,  $this->filter->filter('1993-01-18T07:08:48'));
-        $this->assertEquals(309452625,  $this->filter->filter('1979-10-22T15:03:45'));
-        $this->assertEquals(475393880,  $this->filter->filter('1985-01-24T05:51:20'));
-        $this->assertEquals(1029040935, $this->filter->filter('2002-08-11T04:42:15'));
-        $this->assertEquals(768960737,  $this->filter->filter('1994-05-15T00:12:17'));
-        $this->assertEquals(935307910,  $this->filter->filter('1999-08-22T07:45:10'));
-        $this->assertEquals(895045772,  $this->filter->filter('1998-05-13T07:49:32'));
-        $this->assertEquals(1397034219, $this->filter->filter('2014-04-09T09:03:39'));
+        date_default_timezone_set($timezone);
+        $this->assertEquals($timestamp, $this->filter->filter($datetime));
+    }
+
+    public function defaultProvider()
+    {
+        return [
+            ['UTC', "2016-06-02T15:49:57", 1464882597],
+            ['Europe/Berlin', "2016-06-02T15:49:57", 1464882597],
+            ['UTC', '1972-10-12T15:50:00', 87753000],
+            ['UTC', '2011-08-01T11:15:08', 1312197308],
+            ['UTC', '1997-06-19T17:03:48', 866739828],
+            ['UTC', '2016-03-04T04:39:29', 1457066369],
+            ['UTC', '2004-12-09T19:03:14', 1102618994],
+            ['UTC', '2016-05-27T00:09:08', 1464307748],
+            ['UTC', '1978-11-09T05:26:14', 279437174],
+            ['UTC', '1976-12-27T11:12:07', 220533127],
+            ['UTC', '1981-09-09T09:47:30', 368876850],
+            ['UTC', '2007-12-01T20:12:01', 1196539921],
+            ['UTC', '1976-02-02T06:10:16', 192089416],
+            ['UTC', '1984-03-16T12:15:05', 448287305],
+            ['UTC', '1992-11-27T22:44:59', 722904299],
+            ['UTC', '1970-03-28T00:22:37', 7431757],
+            ['UTC', '1971-02-03T00:48:56', 34390136],
+            ['UTC', '2015-04-14T20:16:21', 1429042581],
+            ['UTC', '1985-05-21T16:43:27', 485541807],
+            ['UTC', '1985-09-10T16:02:03', 495216123],
+            ['UTC', '2013-04-12T02:15:17', 1365732917],
+            ['UTC', '1993-10-15T19:15:47', 750712547],
+            ['UTC', '2005-05-08T17:43:01', 1115574181],
+            ['UTC', '2001-01-06T09:01:10', 978771670],
+            ['UTC', '2006-05-28T14:55:37', 1148828137],
+            ['UTC', '1991-01-22T10:50:46', 664541446],
+            ['UTC', '1992-10-22T17:31:13', 719775073],
+            ['UTC', '1971-02-27T13:27:22', 36509242],
+            ['UTC', '1991-07-15T23:49:33', 679621773],
+            ['UTC', '1972-01-27T18:47:41', 65386061],
+            ['UTC', '2015-11-29T16:33:38', 1448814818],
+            ['UTC', '1987-04-25T21:15:28', 546383728],
+            ['UTC', '1972-02-25T11:41:33', 67866093],
+            ['UTC', '1972-04-08T02:57:20', 71549840],
+            ['UTC', '1982-06-22T03:04:18', 393563058],
+            ['UTC', '1999-08-14T04:45:20', 934605920],
+            ['UTC', '1972-01-07T02:10:30', 63598230],
+            ['UTC', '1970-12-27T16:41:13', 31164073],
+            ['UTC', '1999-08-05T23:28:10', 933895690],
+            ['UTC', '1980-11-14T07:36:44', 343035404],
+            ['UTC', '1977-12-23T03:53:19', 251697199],
+            ['UTC', '2011-04-14T09:15:40', 1302772540],
+            ['UTC', '1972-05-12T22:22:27', 74557347],
+            ['UTC', '1984-01-24T10:03:35', 443786615],
+            ['UTC', '1979-01-24T16:04:27', 286041867],
+            ['UTC', '1995-04-09T21:07:26', 797461646],
+            ['UTC', '1984-04-19T10:26:12', 451218372],
+            ['UTC', '1980-02-26T16:53:22', 320432002],
+            ['UTC', '1994-02-17T11:57:29', 761486249],
+            ['UTC', '1999-09-08T03:09:39', 936760179],
+            ['UTC', '1995-11-06T08:55:25', 815648125],
+            ['UTC', '1970-01-01T00:00:00', 0],
+        ];
     }
 
     /**

--- a/test/Filter/TimestampToDateTimeTest.php
+++ b/test/Filter/TimestampToDateTimeTest.php
@@ -10,63 +10,83 @@ class TimestampToDateTimeTest extends PHPUnit_Framework_TestCase
 {
     protected $filter;
 
+    protected $defaultTimezone;
+
     public function setUp()
     {
         $this->filter = new Filter();
+        $this->defaultTimezone = date_default_timezone_get();
     }
 
-    public function testDefault()
+    public function tearDown()
     {
-        $this->assertEquals('1972-10-12T15:50:00', $this->filter->filter(87753000));
-        $this->assertEquals('2011-08-01T11:15:08', $this->filter->filter(1312197308));
-        $this->assertEquals('1997-06-19T17:03:48', $this->filter->filter(866739828));
-        $this->assertEquals('2016-03-04T04:39:29', $this->filter->filter(1457066369));
-        $this->assertEquals('2004-12-09T19:03:14', $this->filter->filter(1102618994));
-        $this->assertEquals('2016-05-27T00:09:08', $this->filter->filter(1464307748));
-        $this->assertEquals('1978-11-09T05:26:14', $this->filter->filter(279437174));
-        $this->assertEquals('1976-12-27T11:12:07', $this->filter->filter(220533127));
-        $this->assertEquals('1981-09-09T09:47:30', $this->filter->filter(368876850));
-        $this->assertEquals('2007-12-01T20:12:01', $this->filter->filter(1196539921));
-        $this->assertEquals('1976-02-02T06:10:16', $this->filter->filter(192089416));
-        $this->assertEquals('1984-03-16T12:15:05', $this->filter->filter(448287305));
-        $this->assertEquals('1992-11-27T22:44:59', $this->filter->filter(722904299));
-        $this->assertEquals('1970-03-28T00:22:37', $this->filter->filter(7431757));
-        $this->assertEquals('1971-02-03T00:48:56', $this->filter->filter(34390136));
-        $this->assertEquals('2015-04-14T20:16:21', $this->filter->filter(1429042581));
-        $this->assertEquals('1985-05-21T16:43:27', $this->filter->filter(485541807));
-        $this->assertEquals('1985-09-10T16:02:03', $this->filter->filter(495216123));
-        $this->assertEquals('2013-04-12T02:15:17', $this->filter->filter(1365732917));
-        $this->assertEquals('1993-10-15T19:15:47', $this->filter->filter(750712547));
-        $this->assertEquals('2005-05-08T17:43:01', $this->filter->filter(1115574181));
-        $this->assertEquals('2001-01-06T09:01:10', $this->filter->filter(978771670));
-        $this->assertEquals('2006-05-28T14:55:37', $this->filter->filter(1148828137));
-        $this->assertEquals('1991-01-22T10:50:46', $this->filter->filter(664541446));
-        $this->assertEquals('1992-10-22T17:31:13', $this->filter->filter(719775073));
-        $this->assertEquals('1971-02-27T13:27:22', $this->filter->filter(36509242));
-        $this->assertEquals('1991-07-15T23:49:33', $this->filter->filter(679621773));
-        $this->assertEquals('1972-01-27T18:47:41', $this->filter->filter(65386061));
-        $this->assertEquals('2015-11-29T16:33:38', $this->filter->filter(1448814818));
-        $this->assertEquals('1987-04-25T21:15:28', $this->filter->filter(546383728));
-        $this->assertEquals('1972-02-25T11:41:33', $this->filter->filter(67866093));
-        $this->assertEquals('1972-04-08T02:57:20', $this->filter->filter(71549840));
-        $this->assertEquals('1982-06-22T03:04:18', $this->filter->filter(393563058));
-        $this->assertEquals('1999-08-14T04:45:20', $this->filter->filter(934605920));
-        $this->assertEquals('1972-01-07T02:10:30', $this->filter->filter(63598230));
-        $this->assertEquals('1970-12-27T16:41:13', $this->filter->filter(31164073));
-        $this->assertEquals('1999-08-05T23:28:10', $this->filter->filter(933895690));
-        $this->assertEquals('1980-11-14T07:36:44', $this->filter->filter(343035404));
-        $this->assertEquals('1977-12-23T03:53:19', $this->filter->filter(251697199));
-        $this->assertEquals('2011-04-14T09:15:40', $this->filter->filter(1302772540));
-        $this->assertEquals('1972-05-12T22:22:27', $this->filter->filter(74557347));
-        $this->assertEquals('1984-01-24T10:03:35', $this->filter->filter(443786615));
-        $this->assertEquals('1979-01-24T16:04:27', $this->filter->filter(286041867));
-        $this->assertEquals('1995-04-09T21:07:26', $this->filter->filter(797461646));
-        $this->assertEquals('1984-04-19T10:26:12', $this->filter->filter(451218372));
-        $this->assertEquals('1980-02-26T16:53:22', $this->filter->filter(320432002));
-        $this->assertEquals('1994-02-17T11:57:29', $this->filter->filter(761486249));
-        $this->assertEquals('1999-09-08T03:09:39', $this->filter->filter(936760179));
-        $this->assertEquals('1995-11-06T08:55:25', $this->filter->filter(815648125));
-        $this->assertEquals('1970-01-01T00:00:00', $this->filter->filter(0));
+        date_default_timezone_set($this->defaultTimezone);
+        parent::tearDown();
+    }
+
+    /** @dataProvider defaultProvider */
+    public function testDefault($timezone, $datetime, $timestamp)
+    {
+        date_default_timezone_set($timezone);
+        $this->assertEquals($datetime, $this->filter->filter($timestamp));
+    }
+
+    public function defaultProvider()
+    {
+        return [
+            ['Europe/Berlin', '2016-06-02T15:49:57', 1464882597],
+            ['UTC', '2016-06-02T15:49:57', 1464882597],
+            ['UTC', '1972-10-12T15:50:00', 87753000],
+            ['UTC', '2011-08-01T11:15:08', 1312197308],
+            ['UTC', '1997-06-19T17:03:48', 866739828],
+            ['UTC', '2016-03-04T04:39:29', 1457066369],
+            ['UTC', '2004-12-09T19:03:14', 1102618994],
+            ['UTC', '2016-05-27T00:09:08', 1464307748],
+            ['UTC', '1978-11-09T05:26:14', 279437174],
+            ['UTC', '1976-12-27T11:12:07', 220533127],
+            ['UTC', '1981-09-09T09:47:30', 368876850],
+            ['UTC', '2007-12-01T20:12:01', 1196539921],
+            ['UTC', '1976-02-02T06:10:16', 192089416],
+            ['UTC', '1984-03-16T12:15:05', 448287305],
+            ['UTC', '1992-11-27T22:44:59', 722904299],
+            ['UTC', '1970-03-28T00:22:37', 7431757],
+            ['UTC', '1971-02-03T00:48:56', 34390136],
+            ['UTC', '2015-04-14T20:16:21', 1429042581],
+            ['UTC', '1985-05-21T16:43:27', 485541807],
+            ['UTC', '1985-09-10T16:02:03', 495216123],
+            ['UTC', '2013-04-12T02:15:17', 1365732917],
+            ['UTC', '1993-10-15T19:15:47', 750712547],
+            ['UTC', '2005-05-08T17:43:01', 1115574181],
+            ['UTC', '2001-01-06T09:01:10', 978771670],
+            ['UTC', '2006-05-28T14:55:37', 1148828137],
+            ['UTC', '1991-01-22T10:50:46', 664541446],
+            ['UTC', '1992-10-22T17:31:13', 719775073],
+            ['UTC', '1971-02-27T13:27:22', 36509242],
+            ['UTC', '1991-07-15T23:49:33', 679621773],
+            ['UTC', '1972-01-27T18:47:41', 65386061],
+            ['UTC', '2015-11-29T16:33:38', 1448814818],
+            ['UTC', '1987-04-25T21:15:28', 546383728],
+            ['UTC', '1972-02-25T11:41:33', 67866093],
+            ['UTC', '1972-04-08T02:57:20', 71549840],
+            ['UTC', '1982-06-22T03:04:18', 393563058],
+            ['UTC', '1999-08-14T04:45:20', 934605920],
+            ['UTC', '1972-01-07T02:10:30', 63598230],
+            ['UTC', '1970-12-27T16:41:13', 31164073],
+            ['UTC', '1999-08-05T23:28:10', 933895690],
+            ['UTC', '1980-11-14T07:36:44', 343035404],
+            ['UTC', '1977-12-23T03:53:19', 251697199],
+            ['UTC', '2011-04-14T09:15:40', 1302772540],
+            ['UTC', '1972-05-12T22:22:27', 74557347],
+            ['UTC', '1984-01-24T10:03:35', 443786615],
+            ['UTC', '1979-01-24T16:04:27', 286041867],
+            ['UTC', '1995-04-09T21:07:26', 797461646],
+            ['UTC', '1984-04-19T10:26:12', 451218372],
+            ['UTC', '1980-02-26T16:53:22', 320432002],
+            ['UTC', '1994-02-17T11:57:29', 761486249],
+            ['UTC', '1999-09-08T03:09:39', 936760179],
+            ['UTC', '1995-11-06T08:55:25', 815648125],
+            ['UTC', '1970-01-01T00:00:00', 0],
+        ];
     }
 
     /**


### PR DESCRIPTION
Adds tests-cases for different server-timezones just to be sure that the server-timezone does not interfere with the filter.
