### PR TITLE
guzzle 7 update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "license": "BSD-3-Clause",
     "require": {
         "php": "^7.1",
-        "guzzlehttp/guzzle": "^6.5"
+        "guzzlehttp/guzzle": "^6.5 || ^7.0"
     },
     "require-dev": {
         "fzaninotto/faker": "^1.9",


### PR DESCRIPTION
checked https://github.com/guzzle/guzzle/blob/master/UPGRADING.md 

This change is needed for us because guzzle 7 is required from laravel 8.
The implementation of guzzle still works with guzzle 7.